### PR TITLE
develop(elm): provision elm-language-server and elm-format

### DIFF
--- a/flake/develop.nix
+++ b/flake/develop.nix
@@ -19,6 +19,7 @@
 
           inputs.elm2nix.packages.${system}.default
           elmPackages.elm
+          elmPackages.elm-format
           elmPackages.elm-language-server
         ];
 

--- a/flake/develop.nix
+++ b/flake/develop.nix
@@ -19,6 +19,7 @@
 
           inputs.elm2nix.packages.${system}.default
           elmPackages.elm
+          elmPackages.elm-language-server
         ];
 
         shellHook =


### PR DESCRIPTION
config/tip(nvim): `vim.lsp.enable("elmls")`
config/tip(nvim):
```lua
require("conform").setup({
    -- Map of filetype to formatters
    formatters_by_ft = {
        elm = { "elm-format" },
    },
})
```